### PR TITLE
Update documentation to reflect actual export

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ A profile is a node in the relational tree:
   "regionId": 15, // could be null. refers to a particular region
   "vanId": 23234, // could be null if not connected to VAN or if this profile isn't matched
   "myCampaignVanId": 98234, // could be null if not connected to VAN or if this profile isn't matched
+  "vanMatchStatus": null, // covers automatic, manual, and import matches along with their failues
   "createdMts": 1592958136539, // millisecond unix timestamp
+  "updatedMts": 1714408323525, // millisecond unix timestamp
+  "notes": "10/10 Account No Notes", // can be null, can be empty, contains user-defined data
   "lastUsedEmpowerMts": 1592958136789,  // millisecond unix timestamp
   "currentCtaId": 2164, // which CTA is active for them right now
   "activeCtaIDs": [2164] // placeholder for future functionality of having multiple CTAs per person

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ A profile is a node in the relational tree:
   "regionId": 15, // could be null. refers to a particular region
   "vanId": 23234, // could be null if not connected to VAN or if this profile isn't matched
   "myCampaignVanId": 98234, // could be null if not connected to VAN or if this profile isn't matched
-  "vanMatchStatus": null, // covers automatic, manual, and import matches along with their failues
+  "vanMatchStatus": null, // autoMatched, failedAutoMatch, manuallyMatched, failedManualMatch, matchFromImport, null
   "createdMts": 1592958136539, // millisecond unix timestamp
   "updatedMts": 1714408323525, // millisecond unix timestamp
   "notes": "10/10 Account No Notes", // can be null, can be empty, contains user-defined data


### PR DESCRIPTION
Adds three fields to the API documentation under the Profile object which are not included in the documentation. One of these is new as of https://github.com/getempower/empower/pull/2879 .